### PR TITLE
Use backslashes for default ignore list on windows targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,11 @@ use clap::{Parser, ValueEnum};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 const PROFDATA_FILE: &str = "rust_coverage.profdata";
-const IGNORE_REGEXES: &[&str] = &["\\.cargo/registry", "library/std"];
+#[cfg(not(windows))]
+const IGNORE_REGEXES: &[&str] = &[r"\.cargo/registry", "library/std"];
+
+#[cfg(windows)]
+const IGNORE_REGEXES: &[&str] = &[r"\.cargo\\registry", r"library\\std"];
 
 #[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum OutputFormat {


### PR DESCRIPTION
Thanks for packaging this up, it made it a lot easier to get coverage out (I found it by digging in to the pydantic-core workflows!) 

I'm trying to build a crate+python module for Windows, and so the default ignore list needed updating.

I looked at changing the help text, and it doesn't look easily possible with clap v3, but might be possible on v4. It didn't seem that bad to leave it having `/`